### PR TITLE
fixup! Add [optional] verification when merging chunks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyresumable"
-version = "0.0.4"
+version = "0.0.5"
 description = "A library for creating files chunk-by-chunk"
 authors = [
     "Leon du Toit <l.c.d.toit@usit.uio.no>",

--- a/pyresumable/resumables.py
+++ b/pyresumable/resumables.py
@@ -84,7 +84,7 @@ def session_scope(
 
 def md5sum(filename: str, blocksize: int = 65536) -> str:
     with open(filename, "rb") as f:
-        return file_digest(f, hashlib.md5, _buf_size=blocksize).hexdigest()
+        return file_digest(f, hashlib.md5, _bufsize=blocksize).hexdigest()
 
 
 class AbstractResumable(ABC):

--- a/pyresumable/utils.py
+++ b/pyresumable/utils.py
@@ -34,9 +34,9 @@ class SizeCappedFileReader:
         return size
 
 # Nearly identical to `hashlib.file_digest` implemented in Python 3.11, but for a subset of input types -- we expect to have migrated to 3.11 before we're paying any maintenance cost for our own implementation
-def file_digest(file, digest, /, *, _buf_size=2**18): # Equivalent to upstream
+def file_digest(file, digest, /, *, _bufsize=2**18): # Equivalent to upstream
     hasher = hashlib.new(digest) if isinstance(digest, str) else digest()
-    buf = bytearray(_buf_size)
+    buf = bytearray(_bufsize)
     view = memoryview(buf)
     while size := file.readinto(buf):
         hasher.update(view[:size])


### PR DESCRIPTION
I misspelled the well-known (from `hashlib` upstream) keyword argument `_bufsize` to `hashlib.file_digest`, as `_buf_size`. A test with Python 3.11 which uses `hashlib.file_digest` instead, hitting the code path using `resumables.md5sum`, could have uncovered this issue but my tests with an experimental client did not involve _getting_ resumable information -- which is the only place where `resumables.md5sum` is called, so everything worked for me.

Resolves #10.