### PR TITLE
Permit different threads to work with one resumable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyresumable"
-version = "0.0.6"
+version = "0.0.7"
 description = "A library for creating files chunk-by-chunk"
 authors = [
     "Leon du Toit <l.c.d.toit@usit.uio.no>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyresumable"
-version = "0.0.7rc1"
+version = "0.0.7"
 description = "A library for creating files chunk-by-chunk"
 authors = [
     "Leon du Toit <l.c.d.toit@usit.uio.no>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyresumable"
-version = "0.0.7"
+version = "0.0.7rc1"
 description = "A library for creating files chunk-by-chunk"
 authors = [
     "Leon du Toit <l.c.d.toit@usit.uio.no>",

--- a/pyresumable/resumables.py
+++ b/pyresumable/resumables.py
@@ -199,7 +199,13 @@ class SerialResumable(AbstractResumable):
         super().__init__(work_dir, owner)
         self.work_dir = work_dir
         self.owner = owner
-        self.engine = self._init_db(owner, work_dir)
+        self._thread_local = threading.local() # To hold SQLite objects; SQLite demands e.g. connection objects only be used on the same thread they're created on
+
+    @property
+    def engine(self) -> sqlite3.Connection:
+        if not hasattr(self._thread_local, "engine"):
+            self._thread_local.engine = self._init_db(self.owner, self.work_dir)
+        return self._thread_local.engine
 
     def _init_db(
         self,

--- a/pyresumable/resumables.py
+++ b/pyresumable/resumables.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import sqlite3
 import stat
+import threading
 import uuid
 from abc import ABC
 from abc import abstractmethod


### PR DESCRIPTION
Due to SQLite limitations, where a connection created (`sqlite3.connect`) by one thread cannot be used by another, if use of a `SerialResumable` is effectively distributed across multiple threads -- as part of off-loading operations that would otherwise be tying up the `asyncio` event loop, for example -- then SQLite will raise errors when called to execute [SQL] statements.

This change makes creation of the connection object (which is what pins the thread from SQLite's perspective) "lazy" _and_ uses thread-local storage to create a map of connections keyed by the thread. SQLite3 connections are cheap and one could conceivably just create the connection before every query, but if we could cache them _afterwards_ for [later] reuse by the same thread... Well, this is what the thread-local attribute `_thread_local` is for -- if a resumable is worked on by different threads, each will use its own equivalent connection, which permits any thread to work on the same resumable, eliminating the off-loading impediment.